### PR TITLE
feat(julia): update to 1.5.2 and add AWS/SM tools

### DIFF
--- a/examples/jupyter-docker-stacks-julia-image/Dockerfile
+++ b/examples/jupyter-docker-stacks-julia-image/Dockerfile
@@ -1,1 +1,13 @@
-FROM jupyter/datascience-notebook:julia-1.4.1
+FROM jupyter/datascience-notebook:julia-1.5.2
+
+# Install the AWS CLI:
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip
+USER root
+RUN ./aws/install
+USER $NB_UID
+
+# Install various Python utilities for SageMaker, and PyCall to enable using them from Julia:
+RUN julia -e 'import Pkg; Pkg.update()' && \
+    julia -e 'using Pkg; pkg"add PyCall"; pkg"precompile"' && \
+    pip install boto3 sagemaker sagemaker-experiments sagemaker-studio-image-build smdebug

--- a/examples/jupyter-docker-stacks-julia-image/Dockerfile
+++ b/examples/jupyter-docker-stacks-julia-image/Dockerfile
@@ -8,6 +8,12 @@ RUN ./aws/install
 USER $NB_UID
 
 # Install various Python utilities for SageMaker, and PyCall to enable using them from Julia:
+# (Pinned to last tested major version for repeatability)
 RUN julia -e 'import Pkg; Pkg.update()' && \
-    julia -e 'using Pkg; pkg"add PyCall"; pkg"precompile"' && \
-    pip install boto3 sagemaker sagemaker-experiments sagemaker-studio-image-build smdebug
+    julia -e 'using Pkg; pkg"add PyCall@1"; pkg"precompile"' && \
+    pip install \
+        'boto3>=1,<2' \
+        'sagemaker>=2,<3' \
+        'sagemaker-experiments>=0.1,<0.2' \
+        'sagemaker-studio-image-build>=0.4,<0.5' \
+        'smdebug>=0.9,<0.10'

--- a/examples/jupyter-docker-stacks-julia-image/app-image-config-input.json
+++ b/examples/jupyter-docker-stacks-julia-image/app-image-config-input.json
@@ -3,8 +3,8 @@
     "KernelGatewayImageConfig": {
         "KernelSpecs": [
             {
-                "Name": "julia-1.4",
-                "DisplayName": "Julia 1.4"
+                "Name": "julia-1.5",
+                "DisplayName": "Julia 1.5"
             }
         ],
         "FileSystemConfig": {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Update Julia image base version, and add a range of core installs that'll make it easier to translate existing (often Python-based) SageMaker examples into Julia.

- AWS CLI, to enable e.g. `;aws s3 sync` commands
- `PyCall`, to enable loading Python libraries in Julia
- boto3, sagemaker, and some other relevant Python libraries

I propose this will make the example image easier to use in practice!

**Testing done:**

Verified the image builds and works with SMStudio; that `;aws` shell commands seem to work, and that the Python libs can be imported.

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
