### PR TITLE
Add instructions to fix high UID/GID

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -81,7 +81,7 @@ Ensure your SageMaker Studio execution role has permissions to pull the image fr
 
 ### Files With Unsupported UIDs/GIDs
 
-SageMaker only supports UIDs/GIDs greater than 65535. You shouuld ensure that your container does not have any layers containing a file with a GID/UID higher than 65535.
+SageMaker only supports UIDs/GIDs less than 65535. You should ensure that your container does not have any layers containing a file with a GID/UID higher than 65535.
 
 You can check if you have any files in your Docker image that exceed 65535 by adding the following RUN commands at the end of your Dockerfile
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -81,34 +81,29 @@ Ensure your SageMaker Studio execution role has permissions to pull the image fr
 
 ### Files With Unsupported UIDs/GIDs
 
-SageMaker only supports UIDs/GIDs less than 65535. You should ensure that your container does not have any layers containing a file with a GID/UID higher than 65535.
+SageMaker only supports UIDs/GIDs less than 65535. You should ensure that your container does not have any layers containing a file with a GID/UID higher than 65535 - https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_FileSystemConfig.html.
 
-You can check if you have any files in your Docker image that exceed 65535 by adding the following RUN commands at the end of your Dockerfile
+You can check if you have any files in your Docker image that exceed 65535 by adding the following RUN commands after each RUN command in your Dockerfile. We need to do this after each RUN command instead of once at the end since if files are created in one layer and deleted in another layer, it won't appear in the final Docker image, but will still cause issues when using SageMaker.
 ```
+RUN $YOUR_RUN_COMMAND_HERE
 RUN echo $(sudo find / -gid +65535 -ls 2>/dev/null)
 RUN echo $(sudo find / -uid +65535 -ls 2>/dev/null)
 ```
-or the following commands in a terminal inside the container
+or run the following commands in a terminal inside each intermediate container
 ```
 $ echo $(sudo find / -gid +65535 -ls 2>/dev/null)
 $ echo $(sudo find / -uid +65535 -ls 2>/dev/null)
 ```
 If you find any output from the above commands, you have 2 options:
 
-1. Pinpoint the step in your Dockerfile that creates the files shown in the output append the following to the RUN command in your Dockerfile as shown:
+1. For the step in your Dockerfile that produces output from the previous commands, append the following to that step in your Dockerfile as shown:
   ```
   RUN YOUR_COMMANDS_HERE && echo $(sudo find / -uid +65535 -ls -delete | grep ".") && echo $(sudo find / -gid +65535 -ls -delete | grep ".")
   ```
-  Pinpointing the step that creates these files can be a little tricky, but adding the following lines througout your dockerfile as shown should be able to help narrow the search.
-  
-  ```
-  RUN INSTALL_SOME_PACKAGE_HERE
-  RUN echo $(sudo find / -gid +65535 -ls 2>/dev/null)
-  RUN echo $(sudo find / -uid +65535 -ls 2>/dev/null)
-  ```
-  
+
 2. Use a tool like [docker-squash](https://github.com/jwilder/docker-squash) to remove any unecessary intermediate layers from your Docker build. Using this option, you can simply run the following at the end of your Dockerfile.
 
   ```
   RUN echo $(sudo find / -gid +65535 -ls -delete | grep ".") && echo $(sudo find / -uuid +65535 -ls -delete | grep ".")
   ```
+


### PR DESCRIPTION
As Titled.

Add instructions on how to resolve issues with a container that has files with GIDs/UIDs higher than the SageMaker supported limit of 65535.


https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_FileSystemConfig.html

*Issue #, if available:*

*Description of changes:*
Update DEVELOPMENT.md common issue section with instructions how to resolve the issue where a container has an unsupported GID/UID

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
