### PR TITLE
Update the mount path in app config to avoid being overriden by EFS

### DIFF
--- a/examples/scala-image/app-image-config-input.json
+++ b/examples/scala-image/app-image-config-input.json
@@ -8,7 +8,7 @@
             }
         ],
         "FileSystemConfig": {
-            "MountPath": "/home/jovyan",
+            "MountPath": "/home/jovyan/work",
             "DefaultUid": 1000,
             "DefaultGid": 100
         }


### PR DESCRIPTION
**Description**
As titled

**Motivation**
In the example app config we're using the same path for EFS mount so the kernel specs
under this folder will get overriden by EFS.

**Testing Done**
Successfully launched a scala app after the app image config

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
