### PR TITLE
Add custom image sample for Conda environment

### DIFF
--- a/examples/conda-env-kernel-image/Dockerfile
+++ b/examples/conda-env-kernel-image/Dockerfile
@@ -1,0 +1,4 @@
+FROM continuumio/miniconda3:4.9.2
+
+COPY environment.yml .
+RUN conda env create -f environment.yml

--- a/examples/conda-env-kernel-image/README.md
+++ b/examples/conda-env-kernel-image/README.md
@@ -1,0 +1,65 @@
+## Conda Environments as Kernels
+
+
+### Overview
+
+This custom image sample demonstrates how to create a custom Conda environment in a Docker image and use it as a custom kernel in SageMaker Studio. 
+
+The Conda environment must have the appropriate kernel package installed, for e.g., `ipykernel` for a Python kernel. This example creates a Conda environment called `myenv` with a few Python packages (see [environment.yml](environment.yml)) and the `ipykernel`. SageMaker Studio will automatically recognize this Conda environment as a kernel named `conda-env-myenv-py` (See  [app-image-config-input.json](app-image-config-input.json))
+
+### Building the image
+
+Build the Docker image and push to Amazon ECR. 
+```
+# Modify these as required. The Docker registry endpoint can be tuned based on your current region from https://docs.aws.amazon.com/general/latest/gr/ecr.html#ecr-docker-endpoints
+REGION=<aws-region>
+ACCOUNT_ID=<aws-account-id>
+
+
+# Build and push the image
+IMAGE_NAME=conda-env-kernel
+aws --region ${REGION} ecr get-login-password | docker login --username AWS --password-stdin ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/smstudio-custom
+docker build . -t ${IMAGE_NAME} -t ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/smstudio-custom:${IMAGE_NAME}
+docker push ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/smstudio-custom:${IMAGE_NAME}
+```
+
+### Using with SageMaker Studio
+
+Create a SageMaker Image (SMI) with the image in ECR. 
+
+```bash
+# Role in your account to be used for SMI. Modify as required.
+
+ROLE_ARN=arn:aws:iam::${ACCOUNT_ID}:role/RoleName
+aws --region ${REGION} sagemaker create-image \
+    --image-name ${IMAGE_NAME} \
+    --role-arn ${ROLE_ARN}
+
+aws --region ${REGION} sagemaker create-image-version \
+    --image-name ${IMAGE_NAME} \
+    --base-image "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/smstudio-custom:${IMAGE_NAME}"
+
+# Verify the image-version is created successfully. Do NOT proceed if image-version is in CREATE_FAILED state or in any other state apart from CREATED.
+aws --region ${REGION} sagemaker describe-image-version --image-name ${IMAGE_NAME}
+```
+
+Create a AppImageConfig for this image
+
+```bash
+aws --region ${REGION} sagemaker create-app-image-config --cli-input-json file://app-image-config-input.json
+
+```
+
+Create a Domain, providing the SageMaker Image and AppImageConfig in the Domain input. Replace the placeholders for VPC ID, Subnet IDs, and Execution Role in `create-domain-input.json`
+
+```bash
+aws --region ${REGION} sagemaker create-domain --cli-input-json file://create-domain-input.json
+```
+
+If you have an existing Domain, you can also use the `update-domain`
+
+```bash
+aws --region ${REGION} sagemaker update-domain --cli-input-json file://update-domain-input.json
+```
+
+Create a User Profile, and start a Notebook using the SageMaker Studio launcher.

--- a/examples/conda-env-kernel-image/app-image-config-input.json
+++ b/examples/conda-env-kernel-image/app-image-config-input.json
@@ -1,0 +1,16 @@
+{
+    "AppImageConfigName": "conda-env-kernel-config",
+    "KernelGatewayImageConfig": {
+        "KernelSpecs": [
+            {
+                "Name": "conda-env-myenv-py",
+                "DisplayName": "Python [conda env: myenv]"
+            }
+        ],
+        "FileSystemConfig": {
+            "MountPath": "/root",
+            "DefaultUid": 0,
+            "DefaultGid": 0
+        }
+    }
+}

--- a/examples/conda-env-kernel-image/create-domain-input.json
+++ b/examples/conda-env-kernel-image/create-domain-input.json
@@ -1,0 +1,19 @@
+{
+    "DomainName": "domain-with-custom-conda-env",
+    "VpcId": "<vpc-id>",
+    "SubnetIds": [
+        "<subnet-ids>"
+    ],
+    "DefaultUserSettings": {
+        "ExecutionRole": "<role-arn>",
+        "KernelGatewayAppSettings": {
+            "CustomImages": [
+                {
+                    "ImageName": "conda-env-kernel",
+                    "AppImageConfigName": "conda-env-kernel-config"
+                }
+            ]
+        }
+    },
+    "AuthMode": "IAM"
+}

--- a/examples/conda-env-kernel-image/environment.yml
+++ b/examples/conda-env-kernel-image/environment.yml
@@ -1,0 +1,10 @@
+name: myenv
+channels:
+  - conda-forge
+dependencies:
+  - python=3.8
+  - numpy
+  - awscli
+  - boto3
+  - ipykernel
+

--- a/examples/conda-env-kernel-image/update-domain-input.json
+++ b/examples/conda-env-kernel-image/update-domain-input.json
@@ -1,0 +1,13 @@
+{
+    "DomainId": "<domain-id>",
+    "DefaultUserSettings": {
+        "KernelGatewayAppSettings": {
+            "CustomImages": [
+                {
+                    "ImageName": "conda-env-kernel",
+                    "AppImageConfigName": "conda-env-kernel-config"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This change adds a custom image sample that creates a custom Conda environment from the environment.yml. This is a useful starting point when all the packages are installed in a Conda environment separate from either the root Conda environment or the system Python installation.

*Issue #, if available:*

Addresses #10 


**By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.**
