### PR TITLE
Fix issue #22 - conda-env-kernel-image example is broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+examples/conda-env-kernel-image/.idea/conda-env-kernel-image.iml
+examples/conda-env-kernel-image/.idea/inspectionProfiles/profiles_settings.xml
+examples/conda-env-kernel-image/.idea/modules.xml
+examples/conda-env-kernel-image/.idea/vcs.xml

--- a/examples/conda-env-kernel-image/.idea/.gitignore
+++ b/examples/conda-env-kernel-image/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/examples/conda-env-kernel-image/.idea/.gitignore
+++ b/examples/conda-env-kernel-image/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/examples/conda-env-kernel-image/Dockerfile
+++ b/examples/conda-env-kernel-image/Dockerfile
@@ -1,4 +1,4 @@
 FROM continuumio/miniconda3:4.9.2
 
 COPY environment.yml .
-RUN conda env create -f environment.yml
+RUN conda env update -f environment.yml --prune

--- a/examples/conda-env-kernel-image/README.md
+++ b/examples/conda-env-kernel-image/README.md
@@ -86,7 +86,7 @@ Create a Domain, providing the SageMaker Image and AppImageConfig in the Domain 
 aws --region ${REGION} sagemaker create-domain --cli-input-json file://create-domain-input.json
 ```
 
-If you have an existing Domain, you can also use the `update-domain`
+If you have an existing Domain, you can also use the `update-domain`. Replace the placeholder for Domain ID in `update-domain-input.json`
 
 ```bash
 aws --region ${REGION} sagemaker update-domain --cli-input-json file://update-domain-input.json

--- a/examples/conda-env-kernel-image/README.md
+++ b/examples/conda-env-kernel-image/README.md
@@ -9,7 +9,7 @@ The Conda environment must have the appropriate kernel package installed, for e.
 
 ### Building the image
 
-Build the Docker image and push to Amazon ECR. 
+Build the Docker image. 
 ```
 # Modify these as required. The Docker registry endpoint can be tuned based on your current region from https://docs.aws.amazon.com/general/latest/gr/ecr.html#ecr-docker-endpoints
 REGION=<aws-region>
@@ -23,6 +23,32 @@ aws --region ${REGION} ecr create-repository --repository-name smstudio-custom
 # Build and push the image
 aws --region ${REGION} ecr get-login-password | docker login --username AWS --password-stdin ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/smstudio-custom
 docker build . -t ${IMAGE_NAME} -t ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/smstudio-custom:${IMAGE_NAME}
+docker push ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/smstudio-custom:${IMAGE_NAME}
+```
+
+### Local testing
+
+Run the image locally to verify that the kernels in the image are visible to a Kernel Gateway.
+```
+docker run -it "$IMAGE_NAME" bash
+```
+
+Run the container with a KernelGateway to validate that the kernels are visible from the REST endpoint exposed to the host.
+
+```
+docker run -it -p 8888:8888 "$IMAGE_NAME" bash -c 'pip install jupyter_kernel_gateway  && jupyter-kernelgateway --ip 0.0.0.0 --debug --port 8888'
+```
+
+Verify the Kernel Gateway is started successfully (e.g., *[KernelGatewayApp] Jupyter Kernel Gateway at http://0.0.0.0:8888* in the Docker logs) and validate that you can list the kernelspecs in the the running container
+
+```
+curl http://0.0.0.0:8888/api/kernelspecs
+```
+
+
+### Pushing the image
+Push the Docker image to Amazon ECR
+```
 docker push ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/smstudio-custom:${IMAGE_NAME}
 ```
 

--- a/examples/conda-env-kernel-image/README.md
+++ b/examples/conda-env-kernel-image/README.md
@@ -23,7 +23,6 @@ aws --region ${REGION} ecr create-repository --repository-name smstudio-custom
 # Build and push the image
 aws --region ${REGION} ecr get-login-password | docker login --username AWS --password-stdin ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/smstudio-custom
 docker build . -t ${IMAGE_NAME} -t ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/smstudio-custom:${IMAGE_NAME}
-docker push ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/smstudio-custom:${IMAGE_NAME}
 ```
 
 ### Local testing

--- a/examples/conda-env-kernel-image/README.md
+++ b/examples/conda-env-kernel-image/README.md
@@ -82,7 +82,7 @@ docker push ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/smstudio-custom:${IMAG
 ```
 
 
-Create new App Image Version.
+Create new App Image Version
 ```
 aws --region ${REGION} sagemaker create-image-version \
     --image-name ${IMAGE_NAME} \

--- a/examples/conda-env-kernel-image/app-image-config-input.json
+++ b/examples/conda-env-kernel-image/app-image-config-input.json
@@ -3,12 +3,12 @@
     "KernelGatewayImageConfig": {
         "KernelSpecs": [
             {
-                "Name": "conda-env-myenv-py",
+                "Name": "python3",
                 "DisplayName": "Python [conda env: myenv]"
             }
         ],
         "FileSystemConfig": {
-            "MountPath": "/root",
+            "MountPath": "/home/sagemaker-user",
             "DefaultUid": 0,
             "DefaultGid": 0
         }

--- a/examples/conda-env-kernel-image/app-image-config-input.json
+++ b/examples/conda-env-kernel-image/app-image-config-input.json
@@ -8,7 +8,7 @@
             }
         ],
         "FileSystemConfig": {
-            "MountPath": "/home/sagemaker-user",
+            "MountPath": "/root",
             "DefaultUid": 0,
             "DefaultGid": 0
         }

--- a/examples/conda-env-kernel-image/environment.yml
+++ b/examples/conda-env-kernel-image/environment.yml
@@ -1,8 +1,8 @@
-name: myenv
+name: base
 channels:
   - conda-forge
 dependencies:
-  - python=3.8
+  - python=3.9
   - numpy
   - awscli
   - boto3


### PR DESCRIPTION
*Issue #, if available:*
#22 

*Description of changes:*
Fix conda-env-kernel-image example is broken issue:
- Update `base` `conda` environment instead of creating a new `myenv` one.
- Fixed kernel name to be `python3`, as the one on Image. 
- Fixed `MountPath` to be `/home/sagemaker-user`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
