### PR TITLE
Update Julia to latest stable version 1.8.5

### DIFF
--- a/examples/jupyter-docker-stacks-julia-image/Dockerfile
+++ b/examples/jupyter-docker-stacks-julia-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/datascience-notebook:julia-1.5.2
+FROM jupyter/datascience-notebook:julia-1.8.5
 
 # Install the AWS CLI:
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \


### PR DESCRIPTION
```

Updating Julia to the latest stable version fixed the build: https://julialang.org/downloads/#current_stable_release

```

*Issue #, if available:*


Docker build was failing for this image with the following error:

```
Updating `/opt/julia/environments/v1.5/Project.toml`
  [438e738f] + PyCall v1.95.1
Updating `/opt/julia/environments/v1.5/Manifest.toml`
  [1914dd2f] + MacroTools v0.5.10
  [438e738f] + PyCall v1.95.1
   Building PyCall → `/opt/julia/packages/PyCall/twYvK/deps/build.log`
Precompiling project...
Found existing installation: PyYAML 5.3.1
ERROR: Cannot uninstall 'PyYAML'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.
The command '/bin/bash -o pipefail -c julia -e 'import Pkg; Pkg.update()' &&     julia -e 'using Pkg; pkg"add PyCall@1"; pkg"precompile"' &&       pip install         'boto3>=1,<2'         'sagemaker>=2,<3'         'sagemaker-experiments>=0.1,<0.2'         'sagemaker-studio-image-build>=0.4,<0.5'         'smdebug>=0.9,<0.10'' returned a non-zero code: 1
```

*Description of changes:*

Updating Julia to the latest stable version fixed the build: https://julialang.org/downloads/#current_stable_release

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
